### PR TITLE
Fix misinterpretation of partially matching packages

### DIFF
--- a/alibuild-generate-module
+++ b/alibuild-generate-module
@@ -29,7 +29,7 @@ for x in `env | cut -f1 -d= | grep -v "^DEFAULT_" | grep -v PKGREVISION | grep -
   REVISION_VALUE=`eval "echo $(echo \\$$(echo ${x}_REVISION))"`
   VERSION_VALUE=`eval "echo $(echo \\$$(echo ${x}_VERSION))"`
   ROOT_PATH_VALUE=`eval "echo $(echo \\$$(echo ${x}_ROOT))"`
-  if echo $FULL_BUILD_REQUIRES | tr [:lower:] [:upper:] | tr - _ | tr \  \\n | grep -q $x; then
+  if echo $FULL_BUILD_REQUIRES | tr [:lower:] [:upper:] | tr - _ | tr \  \\n | grep -q "^$x$"; then
     echo $x is a build_requires. Skipping loading the associated module. >&2
   elif [ -d $ROOT_PATH_VALUE/etc/modulefiles ]; then
     for filename in `find $ROOT_PATH_VALUE/etc/modulefiles -type f ! -name '*.*' | xargs -n1 basename`; do


### PR DESCRIPTION
Without this, O2 would be dropped if O2-customization is a build_requires.